### PR TITLE
docs: update README with new tool names and batch tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ Remove a value from an array property in multiple files.
 | `property` | string | Name of the array property              |
 | `value`    | any    | Value to remove                         |
 
+**Example:**
+
+```json
+// Input
+{ "glob": "**/*.md", "property": "tags", "value": "draft" }
+
+// Output
+{ "updated_count": 15, "updated_files": ["a.md", "b.md", ...] }
+```
+
 ### batch_array_replace
 
 Replace a value in an array property in multiple files.
@@ -158,6 +168,16 @@ Replace a value in an array property in multiple files.
 | `old_value` | any    | Value to replace                        |
 | `new_value` | any    | New value                               |
 
+**Example:**
+
+```json
+// Input
+{ "glob": "**/*.md", "property": "tags", "old_value": "draft", "new_value": "review" }
+
+// Output
+{ "updated_count": 10, "updated_files": ["a.md", "b.md", ...] }
+```
+
 ### batch_array_sort
 
 Sort an array property in multiple files.
@@ -167,6 +187,16 @@ Sort an array property in multiple files.
 | `glob`     | string | Glob pattern relative to base directory |
 | `property` | string | Name of the array property              |
 | `reverse`  | bool   | Sort in descending order (default: false)|
+
+**Example:**
+
+```json
+// Input
+{ "glob": "**/*.md", "property": "tags" }
+
+// Output
+{ "updated_count": 20, "updated_files": ["a.md", "b.md", ...] }
+```
 
 ## Technical Notes
 


### PR DESCRIPTION
## Summary

- Update tool names to match new naming convention (PR #4)
- Add documentation for batch tools (PR #5, #6)
- Simplify examples for readability

## Changes

| Old Name | New Name |
|----------|----------|
| `inspect_frontmatter` | `query_inspect` |
| `query_frontmatter` | `query` |
| `update_frontmatter` | `update` |

New tools documented:
- `batch_update`
- `batch_array_add`
- `batch_array_remove`
- `batch_array_replace`
- `batch_array_sort`

## Test plan

- [x] README renders correctly on GitHub