### PR TITLE
chore: use PAT for release-please and trigger publish on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish to PyPI
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -51,8 +50,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Extract version from tag
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      - name: Extract version from release tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
       - name: Wait for TestPyPI propagation
         run: sleep 30

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary

- Use `RELEASE_PLEASE_TOKEN` (PAT) instead of `GITHUB_TOKEN` for release-please
- Change publish workflow trigger from tag push to release published event

## Background

Tags and releases created with `GITHUB_TOKEN` do not trigger other workflows (infinite loop prevention by GitHub). Using a PAT bypasses this limitation, enabling automatic PyPI publishing when release-please creates a release.

## Test plan

- [ ] After merging to main, verify that the publish workflow runs automatically when a release PR is merged