### PR TITLE
chore: update uv.lock in release-please workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - name: Set up Python
-        run: uv python install 3.11
-      - name: Install dependencies
-        run: uv sync --group dev
-      - name: Run tests
-        run: uv run python -m pytest
+      - run: uv python install
+      - run: uv sync --group dev
+      - run: uv run python -m pytest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,20 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Build package
-        run: uv build
-
-      - name: Upload dist
-        uses: actions/upload-artifact@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv python install
+      - run: uv build
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -34,32 +24,21 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Download dist
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Extract version from release tag
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
-
-      - name: Wait for TestPyPI propagation
-        run: sleep 30
-
+      - uses: astral-sh/setup-uv@v5
+      - run: uv python install
+      - run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+      - run: sleep 30
       - name: Test install from TestPyPI
         run: |
-          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ frontmatter-mcp==${VERSION}
-          pip show frontmatter-mcp
+          uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ frontmatter-mcp==${VERSION}
+          uv pip show frontmatter-mcp
 
   publish-pypi:
     needs: publish-testpypi
@@ -68,11 +47,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Download dist
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,8 +2,7 @@ name: Release Please
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
 permissions:
   contents: write
@@ -14,5 +13,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - if: steps.release.outputs.pr
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - if: steps.release.outputs.pr
+        uses: astral-sh/setup-uv@v5
+
+      - if: steps.release.outputs.pr
+        run: uv python install
+
+      - if: steps.release.outputs.pr
+        run: uv sync
+
+      - name: Commit uv.lock if changed
+        if: steps.release.outputs.pr
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet uv.lock; then
+            git add uv.lock
+            git commit -m "chore: update uv.lock"
+            git push
+          fi


### PR DESCRIPTION
## Summary

- Release Please が Release PR を作成する際、`pyproject.toml` のバージョンは更新されるが `uv.lock` は更新されない
- この不整合により、次のブランチで `uv sync` した際に混乱が生じる
- Release PR 作成後に `uv sync` を実行し、差分があれば `uv.lock` をコミットするステップを追加

## Test plan

- [ ] main にマージ後、次のリリースで Release PR に `uv.lock` の更新がコミットされることを確認