### PR TITLE
test: use array_cosine_similarity instead of distance

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -267,8 +267,8 @@ class TestSemanticSearch:
         assert "query_vec" in result["columns"]
         mock_model.encode.assert_called_with("test query")
 
-    def test_cosine_distance_calculation(self) -> None:
-        """array_cosine_distance works with embeddings."""
+    def test_cosine_similarity_calculation(self) -> None:
+        """array_cosine_similarity works with embeddings."""
         # Create embeddings where a.md is more similar to query than b.md
         query_vec = np.array([1.0, 0.0, 0.0] + [0.0] * 253, dtype=np.float32)
         vec_a = np.array([0.9, 0.1, 0.0] + [0.0] * 253, dtype=np.float32)  # Similar
@@ -291,7 +291,7 @@ class TestSemanticSearch:
         result = execute_query(
             conn,
             """
-            SELECT path, 1 - array_cosine_distance(embedding, embed('query')) as score
+            SELECT path, array_cosine_similarity(embedding, embed('query')) as score
             FROM files
             ORDER BY score DESC
             """,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -509,7 +509,7 @@ class TestSemanticSearchTools:
             server_module.query,
             "**/*.md",
             """SELECT path,
-               1 - array_cosine_distance(embedding, embed('test')) as score
+               array_cosine_similarity(embedding, embed('test')) as score
                FROM files
                ORDER BY score DESC
                LIMIT 2""",


### PR DESCRIPTION
## Summary

- テストで `1 - array_cosine_distance()` を `array_cosine_similarity()` に変更
- `query` ツールの docstring 例と一致させる

## Changes

- `test_query.py`: `test_cosine_distance_calculation` → `test_cosine_similarity_calculation`
- `test_server.py`: クエリ内の関数を変更

## Test plan

- [x] 変更したテストが通ることを確認