### PR TITLE
feat: add index_wait tool for blocking wait on indexing completion

### DIFF
--- a/src/frontmatter_mcp/server.py
+++ b/src/frontmatter_mcp/server.py
@@ -194,8 +194,8 @@ def index_wait(timeout: float = 60.0) -> Response:
 
     Returns:
         Dict with success (bool), state, and indexed_count.
-        - success=true: Indexing completed, semantic search is ready
-        - success=false: Timeout reached, indexing still in progress
+        - success=true: Indexing completed or idle (not started)
+        - success=false: Timeout reached while indexing in progress
     """
     assert _semantic_ctx is not None
     completed = _semantic_ctx.indexer.wait(timeout=timeout)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -499,16 +499,15 @@ class TestSemanticSearchTools:
         assert result["state"] == "ready"
         assert "indexed_count" in result
 
-    def test_index_wait_timeout(
+    def test_index_wait_idle(
         self, semantic_base_dir: Path, mock_semantic_context
     ) -> None:
-        """index_wait returns success=false on timeout."""
-        # Don't start indexing, just check wait behavior when idle
+        """index_wait returns success=true immediately when idle."""
         result = _call(server_module.index_wait, 0.1)
 
         # When idle (never started), wait returns immediately with success=true
-        assert "success" in result
-        assert "state" in result
+        assert result["success"] is True
+        assert result["state"] == "idle"
 
     def test_index_refresh_enabled(
         self, semantic_base_dir: Path, mock_semantic_context


### PR DESCRIPTION
## Summary

- `index_wait(timeout)` ツールを追加
- AI がインデックス完了を待つ際、ポーリング不要に

## Usage

```
index_wait(timeout=60.0)
```

Returns:
- `success=true, state="ready"`: インデックス完了
- `success=false, state="indexing"`: タイムアウト

## Test plan

- [x] `test_index_wait_success`: インデックス完了で success=true
- [x] `test_index_wait_timeout`: タイムアウト時の動作確認