### PR TITLE
fix(ci): use venv instead of --system for TestPyPI install test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,9 @@ jobs:
       - run: sleep 30
       - name: Test install from TestPyPI
         run: |
-          uv pip install --system --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ frontmatter-mcp==${VERSION}
-          uv pip show --system frontmatter-mcp
+          uv venv .venv
+          uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ frontmatter-mcp==${VERSION}
+          uv pip show frontmatter-mcp
 
   publish-pypi:
     needs: publish-testpypi


### PR DESCRIPTION
## Summary

- TestPyPI からのインストールテストで `--system` フラグを使わず venv を使用するように変更

## Background

Ubuntu の Python は externally managed のため、`--system` フラグでのインストールが失敗する:

```
error: The interpreter at /usr is externally managed
```

## Changes

- `uv venv .venv` で仮想環境を作成
- `--system` フラグを削除

## Test plan

- [ ] リリース時に publish workflow が成功することを確認