### PR TITLE
chore: remove TestPyPI install test from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,15 +31,6 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-      - uses: astral-sh/setup-uv@v5
-      - run: uv python install
-      - run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
-      - run: sleep 30
-      - name: Test install from TestPyPI
-        run: |
-          uv venv .venv
-          uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ frontmatter-mcp==${VERSION}
-          uv pip show frontmatter-mcp
 
   publish-pypi:
     needs: publish-testpypi


### PR DESCRIPTION
## Summary

- Remove TestPyPI install verification test from publish workflow
- Keep TestPyPI publish as staging step before PyPI

## Reason

TestPyPI test install was causing publish failures:
- uv index resolution delays for newly uploaded packages
- Version conflicts when re-releasing (TestPyPI doesn't allow re-upload)

TestPyPI publish itself is still valuable for verifying the upload process works before PyPI.