### PR TITLE
fix: remove indexed_count from index_status and index_wait responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,13 @@ This tool is only available when `FRONTMATTER_ENABLE_SEMANTIC=true`.
 
 ```json
 // Output (not started)
-{ "state": "idle", "indexed_count": 0 }
+{ "state": "idle" }
 
 // Output (indexing in progress)
-{ "state": "indexing", "indexed_count": 150 }
+{ "state": "indexing" }
 
 // Output (ready)
-{ "state": "ready", "indexed_count": 665 }
+{ "state": "ready" }
 ```
 
 ### index_refresh

--- a/src/frontmatter_mcp/semantic/indexer.py
+++ b/src/frontmatter_mcp/semantic/indexer.py
@@ -44,24 +44,12 @@ class EmbeddingIndexer:
         self._state = IndexerState.IDLE
         self._lock = threading.Lock()
         self._thread: threading.Thread | None = None
-        self._indexed_count: int = 0
 
     @property
     def state(self) -> IndexerState:
         """Get current indexer state."""
         with self._lock:
             return self._state
-
-    @property
-    def indexed_count(self) -> int:
-        """Get the number of indexed documents.
-
-        Note: Returns 0 until the first indexing completes. This avoids
-        DB lock issues but means the count may not reflect cached embeddings
-        from previous sessions until indexing runs.
-        """
-        with self._lock:
-            return self._indexed_count
 
     def start(self) -> dict[str, Any]:
         """Start background indexing.
@@ -104,7 +92,6 @@ class EmbeddingIndexer:
         finally:
             with self._lock:
                 self._state = IndexerState.READY
-                self._indexed_count = self._cache.count()
 
     def _index_files(self, files: list[Path]) -> None:
         """Index the given files.

--- a/src/frontmatter_mcp/server.py
+++ b/src/frontmatter_mcp/server.py
@@ -173,18 +173,13 @@ def index_status() -> Response:
     """Get the status of the semantic search index.
 
     Returns:
-        Dict with state ("idle", "indexing", "ready") and indexed_count.
+        Dict with state ("idle", "indexing", "ready").
         - idle: Indexing has never been started
-        - indexing: Indexing is in progress (indexed_count shows progress)
+        - indexing: Indexing is in progress
         - ready: Indexing completed, embed() and embedding column available
     """
     assert _semantic_ctx is not None
-    return _build_response(
-        {
-            "state": _semantic_ctx.indexer.state.value,
-            "indexed_count": _semantic_ctx.indexer.indexed_count,
-        }
-    )
+    return _build_response({"state": _semantic_ctx.indexer.state.value})
 
 
 @mcp.tool(enabled=False)
@@ -198,7 +193,7 @@ def index_wait(timeout: float = 60.0) -> Response:
         timeout: Maximum seconds to wait. Default 60.
 
     Returns:
-        Dict with success (bool), state, and indexed_count.
+        Dict with success (bool) and state.
         - success=true: Indexing completed or idle (not started)
         - success=false: Timeout reached while indexing in progress
     """
@@ -208,7 +203,6 @@ def index_wait(timeout: float = 60.0) -> Response:
         {
             "success": completed,
             "state": _semantic_ctx.indexer.state.value,
-            "indexed_count": _semantic_ctx.indexer.indexed_count,
         }
     )
 

--- a/tests/semantic/test_indexer.py
+++ b/tests/semantic/test_indexer.py
@@ -57,7 +57,6 @@ class TestEmbeddingIndexer:
         """EmbeddingIndexer starts in IDLE state."""
         indexer = EmbeddingIndexer(cache, mock_model, lambda: [], base_dir)
         assert indexer.state == IndexerState.IDLE
-        assert indexer.indexed_count == 0
 
     def test_start_indexing(
         self, cache: EmbeddingCache, mock_model: MagicMock, base_dir: Path
@@ -80,7 +79,7 @@ class TestEmbeddingIndexer:
         # Wait for completion
         indexer.wait(timeout=5.0)
         assert indexer.state == IndexerState.READY
-        assert indexer.indexed_count == 2
+        assert cache.count() == 2
 
     def test_duplicate_start(
         self, cache: EmbeddingCache, mock_model: MagicMock, base_dir: Path
@@ -150,7 +149,7 @@ class TestEmbeddingIndexer:
         # First indexing
         indexer.start()
         indexer.wait(timeout=5.0)
-        assert indexer.indexed_count == 2
+        assert cache.count() == 2
 
         # Delete one file
         file_b.unlink()
@@ -160,7 +159,7 @@ class TestEmbeddingIndexer:
         indexer2.start()
         indexer2.wait(timeout=5.0)
 
-        assert indexer2.indexed_count == 1
+        assert cache.count() == 1
         assert cache.get("b.md") is None
 
     def test_empty_content_skipped(
@@ -177,7 +176,7 @@ class TestEmbeddingIndexer:
         indexer.wait(timeout=5.0)
 
         # Only file with content should be indexed
-        assert indexer.indexed_count == 1
+        assert cache.count() == 1
 
     def test_wait_returns_true_on_completion(
         self, cache: EmbeddingCache, mock_model: MagicMock, base_dir: Path
@@ -215,6 +214,6 @@ class TestEmbeddingIndexer:
         indexer.start()
         indexer.wait(timeout=5.0)
 
-        assert indexer.indexed_count == 2
+        assert cache.count() == 2
         assert cache.get("root.md") is not None
         assert cache.get("sub/nested.md") is not None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -481,12 +481,10 @@ class TestSemanticSearchTools:
     def test_index_status_enabled(
         self, semantic_base_dir: Path, mock_semantic_context
     ) -> None:
-        """index_status returns state and indexed_count when enabled."""
+        """index_status returns state when enabled."""
         result = _call(server_module.index_status)
         assert "state" in result
         assert result["state"] in ["idle", "indexing", "ready"]
-        assert "indexed_count" in result
-        assert isinstance(result["indexed_count"], int)
 
     def test_index_wait_success(
         self, semantic_base_dir: Path, mock_semantic_context
@@ -497,7 +495,6 @@ class TestSemanticSearchTools:
 
         assert result["success"] is True
         assert result["state"] == "ready"
-        assert "indexed_count" in result
 
     def test_index_wait_idle(
         self, semantic_base_dir: Path, mock_semantic_context


### PR DESCRIPTION
## Summary

- `index_status` と `index_wait` のレスポンスから `indexed_count` を削除
- `EmbeddingIndexer` から `_indexed_count` 変数と `indexed_count` プロパティを削除

## 背景

`indexed_count` がタイミングによって不正確な値を返す問題があった:
- サーバー再起動後、キャッシュにエントリがあっても `indexed_count: 0` を返す
- `_indexed_count` は `_run_indexing` 完了後にのみ更新される

## 方針

`indexed_count` を完全に削除:
- 進捗追跡が未実装（インデックス中にカウントが増加しない）
- `state` だけで十分（idle/indexing/ready）
- 待機が必要なら `index_wait` ツールを使用できる
- DB ロック問題を回避できる

## Test plan

- [x] `uv run pytest tests/semantic/test_indexer.py tests/test_server.py -v` でテスト通過