### PR TITLE
fix: close cache connection after indexing to prevent DuckDB lock conflicts

### DIFF
--- a/src/frontmatter_mcp/semantic/indexer.py
+++ b/src/frontmatter_mcp/semantic/indexer.py
@@ -90,6 +90,7 @@ class EmbeddingIndexer:
         try:
             self._index_files(files)
         finally:
+            self._cache.close()
             with self._lock:
                 self._state = IndexerState.READY
 


### PR DESCRIPTION
## Summary

- Close `EmbeddingCache` connection after indexing completes to release DuckDB file lock
- Fix query tool failing with lock error after `index_status` returns `ready`

## Background

When running `query` for semantic search after `index_status` returns `ready`, the following error could occur:

```
Error calling tool 'query': IO Error: Could not set lock on file ".../embeddings.duckdb": Conflicting lock is held in ... (PID ...) by user ...
```

The root cause was that `EmbeddingCache`'s DuckDB connection remained open after `_run_indexing` completed, holding the file lock.

## Changes

- Call `cache.close()` in `EmbeddingIndexer._run_indexing`'s finally block
- Close connection before setting `state = READY` to ensure lock is released when `is_ready` becomes `True`

## Test plan

- [x] Add `test_cache_connection_closed_after_indexing` to verify connection is closed
- [x] All existing tests pass