### PR TITLE
feat: add batch_array_unique tool to remove duplicates from arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,25 @@ Sort an array property in multiple files.
 { "updated_count": 20, "updated_files": ["a.md", "b.md", ...] }
 ```
 
+### batch_array_unique
+
+Remove duplicate values from an array property in multiple files.
+
+| Parameter  | Type   | Description                             |
+| ---------- | ------ | --------------------------------------- |
+| `glob`     | string | Glob pattern relative to base directory |
+| `property` | string | Name of the array property              |
+
+**Example:**
+
+```json
+// Input
+{ "glob": "**/*.md", "property": "tags" }
+
+// Output
+{ "updated_count": 5, "updated_files": ["a.md", "b.md", ...] }
+```
+
 ### index_status
 
 Get the status of the semantic search index.


### PR DESCRIPTION
## Summary

- Add `batch_array_unique` tool to remove duplicate values from array properties
- Preserves the order of first occurrence

## Usage

```json
{ "glob": "**/*.md", "property": "tags" }
```

## Behavior

- Removes duplicate elements while preserving order
- Skips if property doesn't exist
- Skips if property is not an array (with warning)
- Skips if array is empty or has single element
- Skips if array has no duplicates

## Test plan

- [x] `test_remove_duplicates`: basic deduplication
- [x] `test_preserve_order`: order preservation
- [x] `test_skip_if_no_duplicates`: skip when no duplicates
- [x] `test_skip_empty_array`: skip empty arrays
- [x] `test_skip_single_element`: skip single element arrays
- [x] `test_skip_if_property_not_exists`: skip missing properties
- [x] `test_skip_non_array_property`: warn on non-array properties