### PR TITLE
docs: add MCP_TIMEOUT configuration for semantic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An MCP server for querying Markdown frontmatter with DuckDB SQL.
 
 ## Configuration
 
+### Basic Usage
+
 ```json
 {
   "mcpServers": {
@@ -20,7 +22,7 @@ An MCP server for querying Markdown frontmatter with DuckDB SQL.
 
 ### With Semantic Search
 
-To enable semantic search, use the `[semantic]` extras:
+Semantic search requires large dependencies (~1GB). Set `MCP_TIMEOUT` to extend installation timeout:
 
 ```json
 {
@@ -30,12 +32,15 @@ To enable semantic search, use the `[semantic]` extras:
       "args": ["--from", "frontmatter-mcp[semantic]", "frontmatter-mcp"],
       "env": {
         "FRONTMATTER_BASE_DIR": "/path/to/markdown/directory",
-        "FRONTMATTER_ENABLE_SEMANTIC": "true"
+        "FRONTMATTER_ENABLE_SEMANTIC": "true",
+        "MCP_TIMEOUT": "300000"
       }
     }
   }
 }
 ```
+
+Note: `MCP_TIMEOUT` is in milliseconds (300000 = 5 minutes).
 
 ## Installation (Optional)
 


### PR DESCRIPTION
## Summary

- Add Basic Usage and With Semantic Search subsections to Configuration
- Document `MCP_TIMEOUT=300000` setting for semantic search to avoid installation timeout
- Explain that semantic extras include ~1GB dependencies

## Background

Semantic search extras include large dependencies (PyTorch ~700-900MB, Transformers ~50-100MB) that cause uvx installation to timeout with Claude Code's default MCP server startup timeout.

## Test plan

- [ ] Verify basic configuration works without timeout issues
- [ ] Verify semantic search configuration with `MCP_TIMEOUT=300000` completes installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)